### PR TITLE
Camera support for multiple players, tweaks, added comments

### DIFF
--- a/Assets/Scenes/Randy's Level.unity
+++ b/Assets/Scenes/Randy's Level.unity
@@ -3346,7 +3346,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 402650, guid: e85d887f148f59a4db202c50f9246282, type: 2}
       propertyPath: m_RootOrder
-      value: 38
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 8253510, guid: e85d887f148f59a4db202c50f9246282, type: 2}
       propertyPath: m_Volume
@@ -3356,6 +3356,14 @@ Prefab:
       propertyPath: m_Volume
       value: .400000006
       objectReference: {fileID: 0}
+    - target: {fileID: 175460, guid: e85d887f148f59a4db202c50f9246282, type: 2}
+      propertyPath: m_Name
+      value: Player 1 Sprite
+      objectReference: {fileID: 0}
+    - target: {fileID: 11442964, guid: e85d887f148f59a4db202c50f9246282, type: 2}
+      propertyPath: inputHelper
+      value: 
+      objectReference: {fileID: 877397615}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: e85d887f148f59a4db202c50f9246282, type: 2}
   m_IsPrefabParent: 0
@@ -4044,6 +4052,152 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f46bf9271d56f4c458a84c393eaf2917, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &704113203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 175460, guid: e85d887f148f59a4db202c50f9246282, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 704113204}
+  - 212: {fileID: 704113210}
+  - 114: {fileID: 704113209}
+  - 61: {fileID: 704113208}
+  - 114: {fileID: 704113207}
+  - 95: {fileID: 704113206}
+  - 50: {fileID: 704113205}
+  m_Layer: 0
+  m_Name: Player 2 Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &704113204
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 453508, guid: e85d887f148f59a4db202c50f9246282, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.05050182, y: 1.87594056, z: 9.703125}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 871422672}
+  m_Father: {fileID: 1878560820}
+  m_RootOrder: 3
+--- !u!50 &704113205
+Rigidbody2D:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 5015312, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: .0500000007
+  m_GravityScale: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!95 &704113206
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 9555324, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 75b0a1651d26645aabcc9e592a9b8218, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+--- !u!114 &704113207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 11442964, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b20c9bf55d3474b949fdb64678fe0e99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  movementSpeed: 5
+  damagedMovementSpeed: 14
+  inputHelper: {fileID: 871422673}
+--- !u!61 &704113208
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 6136544, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_Enabled: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_Offset: {x: .00251731277, y: .140000001}
+  serializedVersion: 2
+  m_Size: {x: .390392125, y: .26301527}
+--- !u!114 &704113209
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 11482136, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7b9b772ca8f8343708a9391d2f7151d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerID: 0
+  hitPoints: 100
+  money: 0
+  poisioned: 0
+  takingDamage: 0
+  canTakeDamage: 1
+  damageSound: {fileID: 8300000, guid: 94f2d903738a08e4abaf7a67b66c8add, type: 3}
+  moneyUIObject: {fileID: 825614090}
+  attackerPos: {x: 0, y: 0, z: 0}
+--- !u!212 &704113210
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 21282156, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 704113203}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_UseLightProbes: 1
+  m_ReflectionProbeUsage: 1
+  m_ProbeAnchor: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_ImportantGI: 0
+  m_AutoUVMaxDistance: .5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 21300002, guid: 60ac68867429446faa6bae09ec1309e8, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &705814845
 GameObject:
@@ -5336,6 +5490,12 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f46bf9271d56f4c458a84c393eaf2917, type: 3}
   m_Color: {r: .558823526, g: 1, b: .63488847, a: 1}
+--- !u!114 &825614090 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11468606, guid: e85d887f148f59a4db202c50f9246282,
+    type: 2}
+  m_PrefabInternal: {fileID: 617113606}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
 --- !u!1 &845297923
 GameObject:
   m_ObjectHideFlags: 0
@@ -5736,6 +5896,22 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f46bf9271d56f4c458a84c393eaf2917, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!4 &871422672 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+  m_PrefabInternal: {fileID: 1682111112}
+--- !u!114 &871422673 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11451882, guid: 356ec7f3f46484fdaa28e5b6620548ce,
+    type: 2}
+  m_PrefabInternal: {fileID: 1682111112}
+  m_Script: {fileID: 11500000, guid: 712d26830547f4238926546687d5cb67, type: 3}
+--- !u!114 &877397615 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11442158, guid: 325d45982dd2843b68603bfd5b8cea79,
+    type: 2}
+  m_PrefabInternal: {fileID: 1994433136}
+  m_Script: {fileID: 11500000, guid: 712d26830547f4238926546687d5cb67, type: 3}
 --- !u!1 &881852209
 GameObject:
   m_ObjectHideFlags: 0
@@ -11335,6 +11511,48 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f46bf9271d56f4c458a84c393eaf2917, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1001 &1682111112
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 704113204}
+    m_Modifications:
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: .000981211662
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: .00588738918
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 408644, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 356ec7f3f46484fdaa28e5b6620548ce, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &1691372492
 GameObject:
   m_ObjectHideFlags: 0
@@ -12473,6 +12691,10 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: d7dd141357db5184b8e323621edb4246, type: 2}
   m_IsPrefabParent: 0
+--- !u!4 &1827585616 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 453508, guid: e85d887f148f59a4db202c50f9246282, type: 2}
+  m_PrefabInternal: {fileID: 617113606}
 --- !u!1 &1845728413
 GameObject:
   m_ObjectHideFlags: 0
@@ -12635,6 +12857,10 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f46bf9271d56f4c458a84c393eaf2917, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!4 &1878560820 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 402650, guid: e85d887f148f59a4db202c50f9246282, type: 2}
+  m_PrefabInternal: {fileID: 617113606}
 --- !u!1001 &1887494260
 Prefab:
   m_ObjectHideFlags: 0
@@ -13537,6 +13763,48 @@ SpriteRenderer:
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f46bf9271d56f4c458a84c393eaf2917, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1001 &1994433136
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1827585616}
+    m_Modifications:
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: .000981211662
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: .00588738918
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 450422, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 325d45982dd2843b68603bfd5b8cea79, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &1995515839
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AI/FollowNodes.cs
+++ b/Assets/Scripts/AI/FollowNodes.cs
@@ -23,12 +23,17 @@ public class FollowNodes : MonoBehaviour {
         if (!pauseMove)
         {
             Vector3 moveDirection = (nodesToFollow[nextNode].position - transform.position).normalized;
+                    //Sets the direction we want to go
             transform.position = transform.position + ((moveDirection * movementSpeed) * Time.deltaTime);
-            if ((transform.position - nodesToFollow[nextNode].position).magnitude < .02)
+                    //Sets the new position of the object ignoring collisions (can transport through colliders)
+            if ((transform.position - nodesToFollow[nextNode].position).magnitude < .02) //Checks if we are within a margin of error
             {
-                pauseMove = true;
-                Invoke("UnpauseMove", delayAtNodes);
-                transform.position = nodesToFollow[nextNode].position;
+                if (!pauseMove)
+                {
+                    pauseMove = true; //Set this to not move
+                    Invoke("UnpauseMove", delayAtNodes); //sets us to move after delay time
+                    transform.position = nodesToFollow[nextNode].position; //forces us to exact coordinates
+                }
 
                 if (mirrorPath)
                 {
@@ -36,8 +41,11 @@ public class FollowNodes : MonoBehaviour {
                     {
                         nextNode++;
                         currentNode++;
+                                //Go to the next node
+
                         if (nextNode >= nodesToFollow.Length)
                         {
+                            //If we are at the end of the nodes, start going down
                             goingUp = false;
                             nextNode = nodesToFollow.Length - 2;
                             currentNode = nodesToFollow.Length - 1;
@@ -47,8 +55,11 @@ public class FollowNodes : MonoBehaviour {
                     {
                         nextNode--;
                         currentNode--;
+                                //Go to previous node
+
                         if (nextNode < 0)
                         {
+                            //if we get back to the start, flip around
                             goingUp = true;
                             nextNode = 1;
                             currentNode = 0;
@@ -57,6 +68,7 @@ public class FollowNodes : MonoBehaviour {
                 }
                 else
                 {
+                    //Loops through nodes if mirror is off.
                     nextNode++;
                     currentNode++;
                     if (nextNode >= nodesToFollow.Length)

--- a/Assets/Scripts/CameraFollow.cs
+++ b/Assets/Scripts/CameraFollow.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 
 public class CameraFollow : MonoBehaviour {
-    public GameObject objectToFollow;
+    public Transform[] objectsToFollow;
     public BoxCollider2D boundingBox;
 
     bool isShaking = false;
@@ -15,10 +15,39 @@ public class CameraFollow : MonoBehaviour {
 	// Update is called once per frame
 	void Update () 
     {
+        Vector3 centerPos = Vector3.zero;
+        float distance = 0;
+                //Setting up variables for later use.
+
+
+        for(int i = 0; i < objectsToFollow.Length; i++)
+        {
+            centerPos += objectsToFollow[i].position; //Add to center position for averaging later
+            if(i != objectsToFollow.Length-1)
+            {
+                distance += Vector3.Distance(objectsToFollow[i].position, objectsToFollow[i + 1].position);
+                        //If we aren't the last object, add the distance of this object to the next
+            }
+        }
+
+        centerPos = (centerPos / objectsToFollow.Length);
+                //Average the positions of the objects to find the center
+
+        distance = (distance / objectsToFollow.Length);
+                //Averages the distance of all the objects
+
         transform.position = new Vector3(
-                                    Mathf.Clamp(objectToFollow.transform.position.x, boundingBox.bounds.min.x, boundingBox.bounds.max.x),
-                                    Mathf.Clamp(objectToFollow.transform.position.y, boundingBox.bounds.min.y, boundingBox.bounds.max.y),
+                                    Mathf.Clamp(centerPos.x, boundingBox.bounds.min.x, boundingBox.bounds.max.x),
+                                    Mathf.Clamp(centerPos.y, boundingBox.bounds.min.y, boundingBox.bounds.max.y),
                                     - 10);
+                //Sets the position to center of all objects, then clamps it to fit inside the camera bounds object
+
+
+        if (distance > 5)
+        {
+            GetComponent<Camera>().orthographicSize = 6 + (distance - 5);
+                    //Only changes the orthographic view if the distance average is greater then 5 units apart.
+        }
         CheckShake();
         //Clamps the camera transform position to the bounds of the CameraBounds object in the scene.
 	}
@@ -31,11 +60,16 @@ public class CameraFollow : MonoBehaviour {
         }
     }
 
-    public void ShakeCamera(float duration = .5f, float strength = .5f)
+    public void ShakeCamera(float duration = .5f, float strength = .5f, bool forceShake = false)  // Shake the camera, with optional values. ShakeCamera() will simply use .5 in place of there being no values this way.
     {
-        shakeStrength = strength;
-        Invoke("StopCameraShake", duration);
-        isShaking = true;
+        
+        if(!IsInvoking("StopCameraShake") || forceShake)
+        {
+            //Only apply this value if there is no shaking already or it is forced with the flag.
+            shakeStrength = strength;
+            Invoke("StopCameraShake", duration);
+            isShaking = true;
+        }
     }
 
     public void StopCameraShake()

--- a/Assets/Scripts/DamageDealer.cs
+++ b/Assets/Scripts/DamageDealer.cs
@@ -22,6 +22,6 @@ public class DamageDealer : MonoBehaviour {
 
     void OnTriggerEnter2D(Collider2D col)
     {
-        col.transform.root.BroadcastMessage("TakeDamage",new CollisionData(damageToDeal,gameObject), SendMessageOptions.DontRequireReceiver);
+        col.transform.BroadcastMessage("TakeDamage",new CollisionData(damageToDeal,gameObject), SendMessageOptions.DontRequireReceiver);
     }
 }

--- a/Assets/Scripts/MoneyPickup.cs
+++ b/Assets/Scripts/MoneyPickup.cs
@@ -12,8 +12,11 @@ public class MoneyPickup : MonoBehaviour {
 
     void OnTriggerEnter2D(Collider2D col)
     {
-        col.transform.root.BroadcastMessage("GiveMoney", moneyToGive, SendMessageOptions.DontRequireReceiver);
+        col.transform.BroadcastMessage("GiveMoney", moneyToGive, SendMessageOptions.DontRequireReceiver);
+                //Send message to whoever picked up the money.
         Camera.main.GetComponent<AudioSource>().PlayOneShot(pickupSound);
+                //Play sound when picked up.
         Destroy(gameObject);
+                //Destroy self after doing all that.
     }
 }

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -46,6 +46,7 @@ public class PlayerMovement : MonoBehaviour
         {
             rb.velocity = (transform.position - playerStats.attackerPos).normalized * damagedMovementSpeed;
             //Calculates direction from the object attacking us and pushes us away at a set speed while taking damage.
+            //This may be changed later to slower speed when damaged. It hasn't been decided yet.
         }
     }
 

--- a/Assets/Scripts/PlayerStatus.cs
+++ b/Assets/Scripts/PlayerStatus.cs
@@ -23,6 +23,7 @@ public class PlayerStatus : MonoBehaviour {
 	// Use this for initialization
 	void Start () {
         rend = GetComponent<Renderer>();
+        Globals.Players.Add(gameObject);
 	}
 	
 	// Update is called once per frame

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -9,10 +9,10 @@ InputManager:
     m_Name: Horizontal1
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: left
-    positiveButton: right
-    altNegativeButton: a
-    altPositiveButton: d
+    negativeButton: a
+    positiveButton: d
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: .00100000005
     sensitivity: 3
@@ -25,10 +25,10 @@ InputManager:
     m_Name: Vertical1
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: down
-    positiveButton: up
-    altNegativeButton: s
-    altPositiveButton: w
+    negativeButton: s
+    positiveButton: w
+    altNegativeButton: 
+    altPositiveButton: 
     gravity: 3
     dead: .00100000005
     sensitivity: 3
@@ -157,14 +157,14 @@ InputManager:
     positiveButton: 
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
-    dead: .189999998
+    gravity: 3
+    dead: .00100000005
     sensitivity: 1
-    snap: 0
+    snap: 1
     invert: 0
-    type: 2
+    type: 0
     axis: 0
-    joyNum: 1
+    joyNum: 2
   - serializedVersion: 3
     m_Name: Vertical1
     descriptiveName: 
@@ -297,14 +297,14 @@ InputManager:
     m_Name: Horizontal2
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: 
+    negativeButton: left
+    positiveButton: right
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
-    dead: .189999998
+    gravity: 3
+    dead: .00100000005
     sensitivity: 1
-    snap: 0
+    snap: 1
     invert: 0
     type: 2
     axis: 0
@@ -313,15 +313,15 @@ InputManager:
     m_Name: Vertical2
     descriptiveName: 
     descriptiveNegativeName: 
-    negativeButton: 
-    positiveButton: 
+    negativeButton: up
+    positiveButton: down
     altNegativeButton: 
     altPositiveButton: 
-    gravity: 0
-    dead: .189999998
+    gravity: 3
+    dead: .00100000005
     sensitivity: 1
-    snap: 0
-    invert: 1
+    snap: 1
+    invert: 0
     type: 2
     axis: 1
     joyNum: 2


### PR DESCRIPTION
**NOTE: Github says "Can't automatically merge", and I'm not sure what that's about. Says I can still do a pull request, so I'm going to.

Added Multiplayer support to the camera. Now centers between all
players, and zooms out as players get too far apart. (may add option to
limit player movement instead of zooming out.
Added comments to FollowNode.cs, MoneyPickup.cs, and PlayerMovement.cs
Fixed input for second player. Second player can now move with arrow
keys where as first player moves with wasd.
Added second player to Randy's Level.
Updated PlayerStatus.cs to support multiplayer individual damage
Updated MoneyPickup and DamageDealer to support multiplayer individual
damage
